### PR TITLE
Put Catch2 checks beind the SI_BUILD_TESTING option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,6 @@ __pycache__/
 .cache
 CMakeUserPresets.json
 
-# CLion specifi
+# CLion specific
 .idea/
 cmake-build-*/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ __pycache__/
 .cache
 CMakeUserPresets.json
 
+# CLion specifi
+.idea/
+cmake-build-*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.4
+
+* Adjusted CMake to only look for Catch2 if tests are being built. Reduces warnings for projects which use another testing framework (e.g. GTest)
+
 ## 2.5.3
 
 * Change building instructions to work with conan 2.0 - This sets the minimum CMake version to 3.23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.5.4
 
-* Adjusted CMake to only look for Catch2 if tests are being built. Reduces warnings for projects which use another testing framework (e.g. GTest)
+* Adjusted CMake to only look for Catch2 if tests are being built. Reduces warnings for projects which use something else (e.g. GTest)
 
 ## 2.5.3
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ project(
 include(GNUInstallDirs)
 include(CTest)
 
-find_package(Catch2)
-
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   set(IS_TOPLEVEL_PROJECT TRUE)
 else()
@@ -25,9 +23,14 @@ option(SI_INSTALL_LIBRARY
 option(SI_BUILD_TESTING "Build and run SI tests " ${IS_TOPLEVEL_PROJECT})
 option(SI_BUILD_DOC "Generate SI documentation" ${IS_TOPLEVEL_PROJECT})
 
-if(NOT Catch2_FOUND)
-  message(WARNING "Catch2 not found, not building tests")
-  set(SI_BUILD_TESTING OFF)
+# Only search for Catch2 if we're doing testing
+# This is to limit the warning output for projects importing SI with FetchContent
+if(SI_BUILD_TESTING)
+  find_package(Catch2)
+  if (NOT Catch2_FOUND)
+    message(WARNING "Catch2 not found, not building tests")
+    set(SI_BUILD_TESTING OFF)
+  endif ()
 endif()
 
 add_library(SI INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ option(SI_BUILD_TESTING "Build and run SI tests " ${IS_TOPLEVEL_PROJECT})
 option(SI_BUILD_DOC "Generate SI documentation" ${IS_TOPLEVEL_PROJECT})
 
 # Only search for Catch2 if we're doing testing
-# This is to limit the warning output for projects importing SI with FetchContent
+# (this reduces the amount of warnings when added via FetchContent or git submodules)
 if(SI_BUILD_TESTING)
   find_package(Catch2)
   if (NOT Catch2_FOUND)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,32 @@ The default installation location for SI is  `/usr/local/lib/SI`. SI can be inst
 
 See [the installation guide](doc/installation-guide.md) for detailed instructions
 
+#### Including with FetchContent
+
+**Note:** Getting SI as a [conan package](https://conan.io/center/si) is preferred.
+
+To install with CMake's FetchContent, add the following to your CMakeLists.txt
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+  SI
+  GIT_REPOSITORY https://gitlab.com/bernedom/SI.git
+  # This will get the latest version
+  # To pin to a specific version or hash, add the version/hash here instead
+  # (e.g. 2.5.1 or 63b267211a6f256f7ba8d5a26e17138bbcf95ba8)
+  GIT_TAG main
+)
+
+FetchContent_MakeAvailable(SI)
+
+# ...
+
+# Link the library to your target. Change this as needed!
+target_link_libraries(${PROJECT_NAME} PUBLIC SI::SI)
+```
+
 ## Packaging
 
 SI is available as 'raw' download from this repository but also as [conan package](https://conan.io/center/si). Getting SI from conan-center is the preferred way.


### PR DESCRIPTION
## Summary

Moves the Catch2 checks to be behind the `SI_BUILD_TESTING` option. When `SI_BUILD_TESTING`, there will be no Catch2 checks.

## Description

Currently the CMakeLists.txt file logs Catch2 checks emit lots of warnings when SI is included by source (e.g. FetchContent, git submodule, etc.) and Catch2 is not on the system. These warnings include the warning in the project itself, but they also include verbose warnings from CMake about not being able to find the Catch2 package (warnings in section below)

For maintainers or contributors to the library, this is the expected default behavior. 

For someone who just includes by source (e.g. FetchContent, git submodule), this is not the expected default behavior. Currently, SI tests are not built by default when the project is included by source, so checks only related to test targets should not be running by default either.

This change set moves the Catch2 checks (and related warnings) behind the `SI_BUILD_TESTING` option. When `SI_BUILD_TESTING` is turned off (the default for source includes), then no Catch2 checks will run. However, when `SI_BUILD_TESTING` is turned on (the default for maintainers and contributors), then the Catch2 checks will run.

### Example Warnings

```
CMake Warning at cmake-build-debug/_deps/SI/CMakeLists.txt:29 (find_package):
  By not providing "FindCatch2.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Catch2", but
  CMake did not find one.

  Could not find a package configuration file provided by "Catch2" with any
  of the following names:

    Catch2Config.cmake
    catch2-config.cmake

  Add the installation prefix of "Catch2" to CMAKE_PREFIX_PATH or set
  "Catch2_DIR" to a directory containing one of the above files.  If "Catch2"
  provides a separate development package or SDK, be sure it has been
  installed.


CMake Warning at CMakeLists.txt:31 (message):
  Catch2 not found, not building tests
```