### PR TITLE
Include missing header to stream.h

### DIFF
--- a/include/SI/stream.h
+++ b/include/SI/stream.h
@@ -15,6 +15,7 @@
 
 #include <istream>
 #include <ostream>
+#include <string>
 
 template <char _symbol, typename _exponent, typename _type, typename _ratio>
 std::ostream &


### PR DESCRIPTION
`<string>` should be included for `std::to_string` function.